### PR TITLE
Fix Shape.text to keep newlines

### DIFF
--- a/vsdx/__init__.py
+++ b/vsdx/__init__.py
@@ -615,7 +615,7 @@ class VisioFile:
                         text = t.text
                     if not text:
                         text = self.get_all_text_from_xml(t)
-            return text.replace('\n','') if text else ""
+            return text if text else ""
 
         @text.setter
         def text(self, value):


### PR DESCRIPTION
Not sure if there was a specific reason why the newline was being removed, but I believe this should be kept intact.