### PR TITLE
Initial Master-to-shape inheritance implementation

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -682,7 +682,7 @@ def test_master_inheritance(filename: str):
 
         # test inheritance for subshapes
         sub_shape_a = shape_a.sub_shapes()[0]
-        assert sub_shape_a.cell_value('LineWeight') == 0.01875
+        assert sub_shape_a.cell_value('LineWeight') == '0.01875'
 
 @pytest.mark.parametrize(('filename'),
                          [('test1.vsdx')])

--- a/tests/test.py
+++ b/tests/test.py
@@ -684,6 +684,36 @@ def test_master_inheritance(filename: str):
         sub_shape_a = shape_a.sub_shapes()[0]
         assert sub_shape_a.cell_value('LineWeight') == '0.01875'
 
+@pytest.mark.parametrize(("filename"),
+                         [('test5_master.vsdx')])
+def test_master_inheritance_setters(filename: str):
+    out_file = f'{basedir}out{os.sep}{filename[:-5]}_test_master_inheritance_setters.vsdx'
+    with VisioFile(os.path.join(basedir, filename)) as vis:
+        page = vis.get_page(0)
+
+        shape_a = page.find_shape_by_text('Shape A')
+        shape_a.set_cell_value('LineWeight', 0.5)
+        shape_a.set_cell_value('LineColor', "#00FF00")
+
+        sub_shape_b = page.find_shape_by_text('Shape B').sub_shapes()[0]
+        sub_shape_b.set_cell_value('LineWeight', 0.5)
+        sub_shape_b.set_cell_value('LineColor', "#00FF00")
+
+        vis.save_vsdx(out_file)
+
+    with VisioFile(out_file) as vis:
+        page = vis.get_page(0)
+
+        shape_a = page.find_shape_by_text('Shape A')
+        assert shape_a.cell_value('LineWeight') == '0.5'
+        assert shape_a.cell_value('LineColor') == "#00FF00"
+
+        sub_shape_b = page.find_shape_by_text('Shape B').sub_shapes()[0]
+        assert sub_shape_b.cell_value('LineWeight') == '0.5'
+        assert sub_shape_b.cell_value('LineColor') == "#00FF00"
+
+
+
 @pytest.mark.parametrize(('filename'),
                          [('test1.vsdx')])
 def test_add_page(filename: str):

--- a/tests/test.py
+++ b/tests/test.py
@@ -650,7 +650,7 @@ def test_remove_page_by_index(filename: str, page_index: int):
         assert len(vis.pages) == page_count - 1
 
 
-@pytest.mark.skip('master inheritence not yet implemented')
+#@pytest.mark.skip('master inheritence not yet implemented')
 @pytest.mark.parametrize(("filename"),
                          [('test5_master.vsdx')])
 def test_master_inheritance(filename: str):
@@ -669,6 +669,7 @@ def test_master_inheritance(filename: str):
                 # nte this is not the correct link to master shape
                 master_shape = master_page.find_shape_by_id(sub.master_shape_ID)
                 print(f"master={master_shape} {master_shape.text if master_shape else 'n/a'}")
+            print('---------------')
 
         # these tests fail until master shape link in place for Shape.text
         assert shape_a

--- a/tests/test.py
+++ b/tests/test.py
@@ -650,7 +650,6 @@ def test_remove_page_by_index(filename: str, page_index: int):
         assert len(vis.pages) == page_count - 1
 
 
-#@pytest.mark.skip('master inheritence not yet implemented')
 @pytest.mark.parametrize(("filename"),
                          [('test5_master.vsdx')])
 def test_master_inheritance(filename: str):

--- a/tests/test.py
+++ b/tests/test.py
@@ -657,8 +657,8 @@ def test_master_inheritance(filename: str):
     with VisioFile(basedir+os.path.join(filename)) as vis:
         page = vis.get_page(0)  # type: VisioFile.Page
         master_page = vis.master_pages[0]  # type: VisioFile.Page
-        shape_a = page.find_shapes_by_text('Shape A')  # type: List[VisioFile.Shape]
-        shape_b = page.find_shapes_by_text('Shape B')  # type: List[VisioFile.Shape]
+        shape_a = page.find_shape_by_text('Shape A')  # type: VisioFile.Shape
+        shape_b = page.find_shape_by_text('Shape B')  # type: VisioFile.Shape
 
         for s in page.shapes[0].sub_shapes():
             print(f"\n\nshape {s.ID} '{s.text}' MasterShapeID:{s.master_shape_ID} MasterID:{s.master_ID}")
@@ -669,11 +669,13 @@ def test_master_inheritance(filename: str):
                 # nte this is not the correct link to master shape
                 master_shape = master_page.find_shape_by_id(sub.master_shape_ID)
                 print(f"master={master_shape} {master_shape.text if master_shape else 'n/a'}")
-            print('---------------')
 
         # these tests fail until master shape link in place for Shape.text
         assert shape_a
         assert shape_b
+
+        assert shape_a.width == 1
+        assert shape_a.height == 0.75
 
 
 @pytest.mark.parametrize(('filename'),

--- a/tests/test.py
+++ b/tests/test.py
@@ -660,6 +660,7 @@ def test_master_inheritance(filename: str):
         shape_a = page.find_shape_by_text('Shape A')  # type: VisioFile.Shape
         shape_b = page.find_shape_by_text('Shape B')  # type: VisioFile.Shape
 
+        '''
         for s in page.shapes[0].sub_shapes():
             print(f"\n\nshape {s.ID} '{s.text}' MasterShapeID:{s.master_shape_ID} MasterID:{s.master_ID}")
             master_shape = master_page.find_shape_by_id(s.master_shape_ID)
@@ -669,14 +670,19 @@ def test_master_inheritance(filename: str):
                 # nte this is not the correct link to master shape
                 master_shape = master_page.find_shape_by_id(sub.master_shape_ID)
                 print(f"master={master_shape} {master_shape.text if master_shape else 'n/a'}")
+        '''
 
         # these tests fail until master shape link in place for Shape.text
         assert shape_a
         assert shape_b
 
+        # test inheritance of cell values
         assert shape_a.width == 1
         assert shape_a.height == 0.75
 
+        # test inheritance for subshapes
+        sub_shape_a = shape_a.sub_shapes()[0]
+        assert sub_shape_a.cell_value('LineWeight') == 0.01875
 
 @pytest.mark.parametrize(('filename'),
                          [('test1.vsdx')])

--- a/vsdx/__init__.py
+++ b/vsdx/__init__.py
@@ -64,7 +64,6 @@ class VisioFile:
         self.app_xml = None
         self.pages = list()  # list of Page objects, populated by open_vsdx_file()
         self.master_pages = list()  # list of Page objects, populated by open_vsdx_file()
-        self.master_id_to_path = dict()
         self.open_vsdx_file()
 
     def __enter__(self):
@@ -1024,8 +1023,6 @@ class VisioFile:
             elif self.master_ID is not None:
                     text = self.master_shape.text
 
-                    # TODO: elif self.master_Shape_ID is  not None:
-
             return text
 
         @text.setter
@@ -1214,7 +1211,7 @@ class VisioFile:
             Note: typically returns one :class:`Shape` object which itself contains :class:`Shape` objects
 
             """
-            return [VisioFile.Shape(shapes, self, self) for shapes in self.xml.findall(f"{namespace}Shapes")]
+            return [VisioFile.Shape(xml=shapes, parent=self, page=self) for shapes in self.xml.findall(f"{namespace}Shapes")]
 
         def set_max_ids(self):
             # get maximum shape id from xml in page

--- a/vsdx/__init__.py
+++ b/vsdx/__init__.py
@@ -193,6 +193,11 @@ class VisioFile:
             if p.name == name:
                 return p
 
+    def get_master_page_by_id(self, id: str):
+        for m in self.master_pages:
+            if m.name == id:
+                return m
+
     def remove_page_by_index(self, index: int):
         """Remove zero-based nth page from VisioFile object
 
@@ -888,10 +893,11 @@ class VisioFile:
             return VisioFile.Shape(xml=new_shape_xml, parent_xml=parent_xml, page=dst_page)
 
 
-        def get_cell_from_master(self, name:str) -> ET.Element:
-            master_path = self.page.vis.master_id_to_path[self.master_ID]
-            master_xml = self.page.vis.master_page_xml_by_file_path[master_path]
-            return master_xml.find(f'.//{namespace}Shape/{namespace}Cell[@N="{name}"]')
+        def get_cell_value_from_master(self, name:str) -> ET.Element:
+            breakpoint()
+            master_page = self.page.vis.get_master_page_by_id(self.master_ID)
+            master_shape = master_page.shapes[0].sub_shapes()[0]  # there's always a single master shape in a master page
+            return master_shape.cell_value(name)
 
         def cell_value(self, name: str):
             cell = self.cells.get(name)
@@ -899,8 +905,7 @@ class VisioFile:
                 return cell.value
 
             if self.master_ID is not None:
-                master_cell = self.get_cell_from_master(name)
-                return master_cell.attrib['V']
+                return self.get_cell_value_from_master(name)
 
             if self.master_shape_ID is not None:
                 pass
@@ -992,9 +997,10 @@ class VisioFile:
 
             if t is None:
                 if self.master_ID is not None:
-                    master_path = self.page.vis.master_id_to_path[self.master_ID]
-                    master_xml = self.page.vis.master_page_xml_by_file_path[master_path]
-                    t = master_xml.find(f'.//{namespace}Shape/{namespace}Text')
+                    breakpoint()
+                    master_page = self.page.vis.get_master_page_by_id(self.master_ID)
+                    master_shape = master_page.shapes.sub_shapes()[0]  # there's always a single master shape in a master page
+                    t = master_shape.text
 
                     # TODO: elif self.master_Shape_ID is  not None:
 

--- a/vsdx/__init__.py
+++ b/vsdx/__init__.py
@@ -911,7 +911,7 @@ class VisioFile:
             master_shape = master_page.shapes[0].sub_shapes()[0]  # there's always a single master shape in a master page
 
             if self.master_shape_ID is not None:
-                master_sub_shape = self.master_shape.find_shape_by_id(self.master_shape_ID)
+                master_sub_shape = master_shape.find_shape_by_id(self.master_shape_ID)
                 return master_sub_shape
 
             return master_shape

--- a/vsdx/__init__.py
+++ b/vsdx/__init__.py
@@ -182,8 +182,8 @@ class VisioFile:
     def get_page_by_name(self, name: str):
         """Get page from VisioFile with matching name
 
-                :param name: The name of the new page
-                :type name: str, optional
+                :param name: The name of the required page
+                :type name: str
 
                 :return: :class:`Page` object representing the page (or None if not found)
                 """
@@ -192,6 +192,15 @@ class VisioFile:
                 return p
 
     def get_master_page_by_id(self, id: str):
+        """Get master page from VisioFile with matching ID.
+
+        Referred by :attr:`Shape.master_ID`.
+
+                :param id: The ID of the required master
+                :type id: str
+
+                :return: :class:`Page` object representing the master page (or None if not found)
+                """
         for m in self.master_pages:
             if m.name == id:
                 return m
@@ -891,10 +900,14 @@ class VisioFile:
             return VisioFile.Shape(xml=new_shape_xml, parent_xml=parent_xml, page=dst_page)
 
 
-        def get_cell_value_from_master(self, name:str) -> ET.Element:
+        @property
+        def master_shape(self):
             master_page = self.page.vis.get_master_page_by_id(self.master_ID)
             master_shape = master_page.shapes[0].sub_shapes()[0]  # there's always a single master shape in a master page
-            return master_shape.cell_value(name)
+            return master_shape
+
+        def get_cell_value_from_master(self, name:str) -> ET.Element:
+            return self.master_shape.cell_value(name)
 
         def cell_value(self, name: str):
             cell = self.cells.get(name)
@@ -996,9 +1009,7 @@ class VisioFile:
                 text = "".join(t.itertext())
 
             elif self.master_ID is not None:
-                    master_page = self.page.vis.get_master_page_by_id(self.master_ID)
-                    master_shape = master_page.shapes[0].sub_shapes()[0]  # there's always a single master shape in a master page
-                    text = master_shape.text
+                    text = self.master_shape.text
 
                     # TODO: elif self.master_Shape_ID is  not None:
 

--- a/vsdx/__init__.py
+++ b/vsdx/__init__.py
@@ -158,16 +158,17 @@ class VisioFile:
         masters_path = f'{self.directory}/visio/masters/masters.xml'
         masters_data = file_to_xml(masters_path)  # contains more info about master page (i.e. Name, Icon)
         masters = masters_data.getroot() if masters_data else None
-        master_elements = masters.findall(f"{namespace}Master")
-        r_namespace = '{http://schemas.openxmlformats.org/officeDocument/2006/relationships}'
-        # dict comprehension
-        self.master_id_to_path = {
-            m.attrib['ID']: relid_to_path[m.find(f"{namespace}Rel").attrib[f"{r_namespace}id"]]
-            for m in master_elements
-        }
+        if masters is not None:
+            master_elements = masters.findall(f"{namespace}Master")
+            r_namespace = '{http://schemas.openxmlformats.org/officeDocument/2006/relationships}'
+            # dict comprehension
+            self.master_id_to_path = {
+                m.attrib['ID']: relid_to_path[m.find(f"{namespace}Rel").attrib[f"{r_namespace}id"]]
+                for m in master_elements
+            }
 
-        if self.debug:
-            print(f"Masters({masters_path})", VisioFile.pretty_print_element(masters))
+            if self.debug:
+                print(f"Masters({masters_path})", VisioFile.pretty_print_element(masters))
 
         return
 
@@ -902,7 +903,7 @@ class VisioFile:
                 return master_cell.attrib['V']
 
             if self.master_shape_ID is not None:
-                breakpoint()
+                pass
 
         def set_cell_value(self, name: str, value: str):
             cell = self.cells.get(name)


### PR DESCRIPTION
For #4 

- Get Cell values and Text values from master shape or sub-shape
- Set Cell values by copying and amending corresponding master shape or sub-shape Cell
- ❗ Change Shape class: it now expects a Page or Shape for a parent, not just the XML
  - This was needed to significantly simplify finding master shape for sub-shapes
  - Instead of shape.parent_xml, now you need to use shape.parent.xml
- Rework and simplify load_master_pages()
  - master pages now have their ID as name, not the relid
  - minor simplification with checking for None before looping

What do you think?