### PR TITLE
fixed performance problems when loading big, complicated vsdx files

### DIFF
--- a/vsdx/pages.py
+++ b/vsdx/pages.py
@@ -51,6 +51,8 @@ class Page:
         self.max_id = 0
         # todo: add page id - from pages_xml - PageSheet[ID]
 
+        self.__shapes = None
+
     def __repr__(self):
         return f"<Page name={self.name} file={self.filename} >"
 
@@ -146,7 +148,10 @@ class Page:
         Note: typically returns one :class:`Shape` object which itself contains :class:`Shape` objects
 
         """
-        return [Shape(xml=shapes, parent=self, page=self) for shapes in self.xml.findall(f"{namespace}Shapes")] or []
+        if self.__shapes is not None:
+            return self.__shapes
+        self.__shapes = [Shape(xml=shapes, parent=self, page=self) for shapes in self.xml.findall(f"{namespace}Shapes")] or []
+        return self.__shapes
 
     @property
     @deprecation.deprecated(deprecated_in="0.5.0", removed_in="1.0.0", current_version=vsdx.__version__,

--- a/vsdx/shapes.py
+++ b/vsdx/shapes.py
@@ -141,6 +141,7 @@ class Shape:
         self.shape_type = xml.attrib.get('Type', None)
         self.shape_name = xml.attrib.get('NameU') or xml.get('Name')
         self.page = page
+        self._child_shapes = None
 
         # get Cells in Shape
         self.cells = dict()
@@ -171,6 +172,8 @@ class Shape:
                         self.cells[key] = cell
 
         self._data_properties = None  # internal field to hold Shape.data_propertes, set by property
+
+        self.__all_shapes = None
 
     def __repr__(self):
         return f"<Shape tag={self.tag} ID={self.ID} is_master=({self.is_master_shape}) type={self.shape_type} text='{self.text}' >"
@@ -659,6 +662,9 @@ class Shape:
                 :returns: list of Shape objects
                 :rtype: List[Shape]
                 """
+        if self._child_shapes is not None:
+            return self._child_shapes
+
         shapes = list()
         # for each shapes tag, look for Shape objects
         # self can be either a Shapes or a Shape
@@ -675,12 +681,16 @@ class Shape:
         else:
             shapes = []
 
+        self._child_shapes = shapes
         return shapes
 
     @property
     def all_shapes(self):
         # return all shapes within another shape, recursively
-        return self._all_shapes()
+        if self.__all_shapes is not None:
+            return self.__all_shapes
+        self.__all_shapes = self._all_shapes()
+        return self.__all_shapes
 
     def _all_shapes(self, shapes: List[Shape] = None) -> List[Shape]:
         # recursively search for shapes and return all found


### PR DESCRIPTION
This is quite naive fix for performance issues.
It caches some instances so they are not repeatedly parsed.
It works for cases when a file is only loaded and read.
Probably it does not work well when the file is modified via this lib - I didn't try that.
Any tips how to improve that appreciated.