### PR TITLE
bugfix: fix check for page_rels_path presence

### DIFF
--- a/vsdx/vsdxfile.py
+++ b/vsdx/vsdxfile.py
@@ -184,7 +184,7 @@ class VisioFile:
             base_page_file_name = page_path.split('/')[-1]
             page_rels_path = rel_dir+base_page_file_name+'.rels'
 
-            if os.path.exists(page_rels_path):
+            if page_rels_path in self.zip_file_contents:
                 new_page.rels_xml_filename = page_rels_path
                 new_page.rels_xml = file_to_xml(page_rels_path, self.zip_file_contents)
             self.pages.append(new_page)


### PR DESCRIPTION
This was silently working for a while until I decided to delete old extracted copies of my visio file