### PR TITLE
bugfix: normalize paths when searching zip dict

### DIFF
--- a/vsdx/connectors.py
+++ b/vsdx/connectors.py
@@ -36,7 +36,7 @@ class Connect:
             media = vsdx.Media()
             connector_shape = media.straight_connector.copy(page)  # default to straight connector
             connector_shape.text = ''  # clear text used to find shape
-            if not os.path.exists(page.vis._masters_folder):
+            if not page.vis._masters_folder in page.vis.zip_file_contents:
                 # Add masters folder to directory if not already present
                 for file_name, file in media._media_vsdx.zip_file_contents.items():
                     if file_name.startswith(media._media_vsdx._masters_folder):

--- a/vsdx/vsdxfile.py
+++ b/vsdx/vsdxfile.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import zipfile
+from collections import UserDict
 import shutil
 import os
 import re
@@ -50,6 +51,25 @@ def xml_to_file(xml: ET.ElementTree, filename: str, zip_file_contents: dict = No
     xml.write(file, xml_declaration=True, method='xml', encoding='UTF-8')
     zip_file_contents[filename] = io.BytesIO(file.getvalue())
 
+class FileDict(UserDict):
+    def _normalize(self, path: os.PathLike) -> str:
+        return os.path.realpath(os.fspath(path))
+
+    def __setitem__(self, key: os.PathLike, value: io.BytesIO):
+        super().__setitem__(self._normalize(key), value)
+
+    def __getitem__(self, key: os.PathLike):
+        return super().__getitem__(self._normalize(key))
+
+    def __contains__(self, key: os.PathLike):
+        return super().__contains__(self._normalize(key))
+
+    def get(self, key: os.PathLike, default=None):
+        return super().get(self._normalize(key), default)
+
+    def pop(self, key: os.PathLike, *args):
+        return super().pop(self._normalize(key), *args)
+
 
 class VisioFileNotOpen(BaseException):
     """Error class to report when a VisioFile is attempted to be saved when no longer open"""
@@ -94,7 +114,7 @@ class VisioFile:
         self.master_index = {}  # dict of master page info by item name e.g. 'Dynamic Connector'
         self.master_pages = list()  # type: List[Page]  # list of Page objects, populated by open_vsdx_file()
         self.file_open = False
-        self.zip_file_contents = {}  # dict of file contents by file_path
+        self.zip_file_contents = FileDict()  # dict of file contents by file_path
         self.open_vsdx_file()
 
     def __enter__(self):
@@ -125,7 +145,7 @@ class VisioFile:
         """Save the zip_file_contents to disk"""
         with zipfile.ZipFile(save_filename, "w") as zipf:
             for file_path, file_content in self.zip_file_contents.items(): # type: tuple(str, io.BytesIO)
-                file_path_in_zip : str = file_path.replace(self.directory+'/', '')
+                file_path_in_zip : str = os.path.relpath(file_path, start=self.directory)
                 
                 if file_path_in_zip.endswith('.xml') or file_path_in_zip.endswith('.rels'):
                     zipf.writestr(file_path_in_zip, file_content.read().decode('utf-8'))

--- a/vsdx/vsdxfile.py
+++ b/vsdx/vsdxfile.py
@@ -37,38 +37,41 @@ ET.register_namespace('', document_rels_namespace[1:-1])
 ET.register_namespace('', cont_types_namespace[1:-1])
 
 
-def file_to_xml(filename: str, zip_file_contents: dict = None) -> ET.ElementTree:
+def normalize_path(path: os.PathLike) -> str:
+    normalized = os.path.realpath(os.fspath(path))
+    if path.endswith(("/", "\\")):
+        normalized += os.path.sep
+    return normalized
+
+class FileDict(UserDict):
+    def __setitem__(self, key: os.PathLike, value: io.BytesIO):
+        super().__setitem__(normalize_path(key), value)
+
+    def __getitem__(self, key: os.PathLike):
+        return super().__getitem__(normalize_path(key))
+
+    def __contains__(self, key: os.PathLike):
+        return super().__contains__(normalize_path(key))
+
+    def get(self, key: os.PathLike, default=None):
+        return super().get(normalize_path(key), default)
+
+    def pop(self, key: os.PathLike, *args):
+        return super().pop(normalize_path(key), *args)
+
+def file_to_xml(filename: str, zip_file_contents: FileDict = None) -> ET.ElementTree:
     """Import a file as an ElementTree"""
     if filename in zip_file_contents:
         content : io.BytesIO = zip_file_contents[filename]
         tree = ET.parse(io.BytesIO(content.getvalue()))
         return tree
 
-
-def xml_to_file(xml: ET.ElementTree, filename: str, zip_file_contents: dict = None):
+def xml_to_file(xml: ET.ElementTree, filename: str, zip_file_contents: FileDict = None):
     """Save an ElementTree to zip_file_contents"""
     file : io.BytesIO = io.BytesIO()
     xml.write(file, xml_declaration=True, method='xml', encoding='UTF-8')
     zip_file_contents[filename] = io.BytesIO(file.getvalue())
 
-class FileDict(UserDict):
-    def _normalize(self, path: os.PathLike) -> str:
-        return os.path.realpath(os.fspath(path))
-
-    def __setitem__(self, key: os.PathLike, value: io.BytesIO):
-        super().__setitem__(self._normalize(key), value)
-
-    def __getitem__(self, key: os.PathLike):
-        return super().__getitem__(self._normalize(key))
-
-    def __contains__(self, key: os.PathLike):
-        return super().__contains__(self._normalize(key))
-
-    def get(self, key: os.PathLike, default=None):
-        return super().get(self._normalize(key), default)
-
-    def pop(self, key: os.PathLike, *args):
-        return super().pop(self._normalize(key), *args)
 
 
 class VisioFileNotOpen(BaseException):
@@ -161,18 +164,18 @@ class VisioFile:
         self.file_open = True
 
     def _pages_filename(self):
-        page_dir = f'{self.directory}/visio/pages/'
+        page_dir = normalize_path(f'{self.directory}/visio/pages/')
         pages_filename = page_dir + 'pages.xml'  # pages.xml contains Page name, width, height, mapped to Id
         return pages_filename
 
     @property
     def _masters_folder(self):
-        path = f"{self.directory}/visio/masters"
+        path = normalize_path(f"{self.directory}/visio/masters/")
         return path
 
     def load_pages(self):
-        rel_dir = f'{self.directory}/visio/pages/_rels/'
-        page_dir = f'{self.directory}/visio/pages/'
+        rel_dir = normalize_path(f'{self.directory}/visio/pages/_rels/')
+        page_dir = normalize_path(f'{self.directory}/visio/pages/')
 
         rel_filename = rel_dir + 'pages.xml.rels'
         rels = file_to_xml(rel_filename, self.zip_file_contents).getroot()  # rels contains page filenames

--- a/vsdx/vsdxfile.py
+++ b/vsdx/vsdxfile.py
@@ -204,7 +204,7 @@ class VisioFile:
 
             new_page = Page(file_to_xml(page_path, self.zip_file_contents), page_path, page_name, page_id, rel_id, self)
             # look for visio/pages/_rels/page3.xml.rels
-            base_page_file_name = page_path.split('/')[-1]
+            base_page_file_name = page_path.split(os.path.sep)[-1]
             page_rels_path = rel_dir+base_page_file_name+'.rels'
 
             if os.path.exists(page_rels_path):


### PR DESCRIPTION
Currently the keys in the dict can have some combination of `\` and `/` separators. This should make that always consistent, and also allow for finding files with `../` in paths as well